### PR TITLE
Update how-to-make-the-macos-app-switcher-appear-on-all-displays.md

### DIFF
--- a/posts/how-to-make-the-macos-app-switcher-appear-on-all-displays.md
+++ b/posts/how-to-make-the-macos-app-switcher-appear-on-all-displays.md
@@ -16,7 +16,7 @@ always visible in the display you're looking at:
 defaults write com.apple.dock appswitcher-all-displays -bool true
 ```
 
-You'll need to restart the Docker for this change to be picked up:
+You'll need to restart the Dock for this change to be picked up:
 
 ```bash
 killall Dock


### PR DESCRIPTION
The process that needs to be restarted is `Dock` rather than `Docker`